### PR TITLE
Comment out "uint8_t last_special;", will not compile on linux (only linux?) with it. 

### DIFF
--- a/src/SpecialStage.c
+++ b/src/SpecialStage.c
@@ -184,7 +184,7 @@ word_u ss_angle;
 uint16_t ss_rotate;
 uint16_t palss_num, palss_time;
 
-uint8_t last_special;
+// uint8_t last_special;
 
 uint8_t emeralds;
 uint8_t emerald_list[8];


### PR DESCRIPTION
On Pop_OS! 22.04, it does not compile, giving this linker error:
```/usr/bin/ld: CMakeFiles/SoniCPort.dir/src/SpecialStage.c.o:(.bss+0x5a09): multiple definition of `last_special'; CMakeFiles/SoniCPort.dir/src/Level.c.o:(.bss+0x4213): first defined here```

I'm not sure if it only happens on Linux...?